### PR TITLE
Allow developers to improve the message they write

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A CLI coding assistant
 
 ## Installation
 You can install the package using below command. Make sure you have Python and pip installed on your system.
-    
+
         - pip install sarathi
- 
+
 
 ## Quickstart
 
@@ -25,9 +25,9 @@ To use certain features of this package, you need to set up your OpenAI API key.
 ## Usage
 
 #### Generating Git Commit Messages
-Sarathi provides a convenient command `sarathi git autocommit` to generate commit messages for Git commits. 
+Sarathi provides a convenient command `sarathi git autocommit` to generate commit messages for Git commits.
 - Stage the files you want to commit
-- Run `sarathi git autocommit`. This command will automatically analyze your staged changes, generate a commit message via OPEN AI, show the generated message to you, and if you confirm, will commit your changes to the repository with the generated message.
+- Run `sarathi git autocommit`. This command will automatically analyze your staged changes, generate a commit message via OPEN AI, and commit the changes automatically. It will then run `git commit --amend` for you to edit the generated commit message.
 
 #### Generating docstring messages
 You can generate docstrings for your python code using commands such as below
@@ -39,4 +39,3 @@ You can generate docstrings for your python code using commands such as below
 ## Helpul references
     - https://dev.to/taikedz/ive-parked-my-side-projects-3o62
     - https://github.com/lightningorb/autocommit
-    

--- a/src/sarathi/cli/cli_handler.py
+++ b/src/sarathi/cli/cli_handler.py
@@ -37,3 +37,7 @@ def main():
             print("Unsupported Option")
     except Exception as e:
         print(f"Exception {e} occured while trying to parse the argument")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sarathi/cli/sgit.py
+++ b/src/sarathi/cli/sgit.py
@@ -49,7 +49,7 @@ def setup_args(subparsers, opname):
     """
     git_parser = subparsers.add_parser(opname)
     git_sub_cmd = git_parser.add_subparsers(dest="git_sub_cmd")
-    commit_op = git_sub_cmd.add_parser("autocommit")
+    git_sub_cmd.add_parser("autocommit")
 
 
 def execute_cmd(args):

--- a/src/sarathi/cli/sgit.py
+++ b/src/sarathi/cli/sgit.py
@@ -28,15 +28,6 @@ def generate_commit_message():
     return llm_response["choices"][0]["message"]["content"]
 
 
-def get_user_confirmation():
-    """Prompts the user for confirmation to proceed.
-
-    Returns:
-        True if user input is y, False otherwise.
-    """
-    return input(f"Do you want to proceed " + format_green("y/n") + ": ").strip() == "y"
-
-
 def setup_args(subparsers, opname):
     """Adds a new sub-parser to the provided subparsers.
 
@@ -65,8 +56,5 @@ def execute_cmd(args):
     if args.git_sub_cmd == "autocommit":
         generated_commit_msg = generate_commit_message()
         if generated_commit_msg:
-            print(generated_commit_msg)
-            if get_user_confirmation():
-                subprocess.run(["git", "commit", "-m", generated_commit_msg])
-            else:
-                print("I would try to generate a better commit msgs next time")
+            subprocess.run(["git", "commit", "-m", generated_commit_msg])
+            subprocess.run(["git", "commit", "--amend"])


### PR DESCRIPTION
This PR updates the `git autocommit` command by removing the confirmation prompt and instead committing the message returned by OpenAI directly. To give the opportunity to developer to update the message, it then executes `git commit --amend` immediately for the developer to update the commit.

The new behavior had been tested by dogfooding on the development branch itself.

Resolves #21 .

In addition:

* This PR adds a call to `main()` function in `cli_handler.py` so that the code can be run using `python -m` command on the command prompt.
* This PR removes an unused variable in sgit.setup_args.