### PR TITLE
Update prompt_dict with new GPT model versions

### DIFF
--- a/src/sarathi/llm/prompts.py
+++ b/src/sarathi/llm/prompts.py
@@ -1,6 +1,6 @@
 prompt_dict = {
     "autocommit": {
-        "system_msg": """ 
+        "system_msg": """
                          Your task is to generate a commit message based on the diff provided. Please follow below guidelines while generating the commit message
                           - Think like a software developer
                           - Provide a high level description of changes
@@ -13,19 +13,19 @@ prompt_dict = {
                           - If you think the diff fixes a comminbug, security issue or CVE which you know about, mention that in your response
                           - Do not repeat instructions in commit message
                         """,
-        "model": "gpt-3.5-turbo",
+        "model": "gpt-4o-mini",
     },
     "qahelper": {
-        "system_msg": """ 
+        "system_msg": """
                          Your task is to answer the below question to the best of your knowledge. Please follow below guidelines
                           - Think like a principal software engineer who is assiting a junior developer
                           - Do not give any nasty comments or answers.
                           - If you do not know the answer do not make it up, just say 'sorry I do not know answer to that question'
                       """,
-        "model": "gpt-3.5-turbo",
+        "model": "gpt-4o-mini",
     },
     "update_docstrings": {
-        "system_msg": """ 
+        "system_msg": """
                          Your task is to generate Google style docstrings format for the python code provided below. Please follow below guidelines while generating the docstring
                         -  docstrings should be generated in Google style docstrings format. An example is mentioned below
                                 \"\"\"Reads the content of a file.
@@ -41,6 +41,6 @@ prompt_dict = {
                         -  do not mention any single quotes or double quotes in the response
                         -  if you do not know the answer do not make it up, just say sorry I do not know that
                     """,
-        "model": "gpt-3.5-turbo",
+        "model": "gpt-4o-mini",
     },
 }


### PR DESCRIPTION
Update GPT model versions in prompt_dict for `autocommit`, `qahelper`, and `update_docstrings` prompts.

GPT-4o mini is cheaper and more capable than GPT-3.5 Turbo, see https://platform.openai.com/docs/models/gpt-4o-mini