### PR TITLE
Retrieve API key from OPENAI_API_KEY in case SARATHI_OPENAI_API_KEY is undefined for backward compatibility

### DIFF
--- a/src/sarathi/llm/call_llm.py
+++ b/src/sarathi/llm/call_llm.py
@@ -1,6 +1,29 @@
 import os
-
 import requests
+
+
+def retrieve_api_key():
+    """Retrieves the OpenAI API key from environment variables.
+
+    This function attempts to retrieve the API key from two possible environment variables:
+    SARATHI_OPENAI_API_KEY and OPENAI_API_KEY. If neither variable is set, it raises
+    a ValueError.
+
+    Returns:
+        The OpenAI API key as a string.
+
+    Raises:
+        ValueError: If neither environment variable is found.
+    """
+    try:
+        return os.environ["SARATHI_OPENAI_API_KEY"]
+    except Exception as e:
+        try:
+            return os.environ["OPENAI_API_KEY"]
+        except Exception as e:
+            raise ValueError(
+                "Exception occured: neither SARATHI_OPENAI_API_KEY nor OPENAI_API_KEY is found"
+            )
 
 
 def call_llm_model(prompt_info, user_msg, resp_type=None):
@@ -14,30 +37,26 @@ def call_llm_model(prompt_info, user_msg, resp_type=None):
 
     Returns:
     """
-    try:
-        url = "https://api.openai.com/v1/chat/completions"
-        model = prompt_info["model"]
-        system_msg = prompt_info["system_msg"]
-        headers = {
-            "Authorization": "Bearer " + os.environ["SARATHI_OPENAI_API_KEY"],
-            "Content-Type": "application/json",
-        }
-        body = {
-            "model": model,
-            "messages": [
-                {"role": "system", "content": system_msg},
-                {"role": "user", "content": user_msg},
-            ],
-            "max_tokens": 100,
-            "n": 1,
-            "stop": None,
-            "temperature": 0.7,
-        }
-        response = requests.post(url, headers=headers, json=body)
-        if resp_type == "text":
-            text_resp = response.json()["choices"][0]["message"]["content"]
-            return text_resp
-        return response.json()
-    except Exception as e:
-        if str(e) == "'OPENAI_API_KEY'":
-            raise ValueError("Exception occured " + str(e) + " not found")
+    url = "https://api.openai.com/v1/chat/completions"
+    model = prompt_info["model"]
+    system_msg = prompt_info["system_msg"]
+    headers = {
+        "Authorization": "Bearer " + retrieve_api_key(),
+        "Content-Type": "application/json",
+    }
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_msg},
+            {"role": "user", "content": user_msg},
+        ],
+        "max_tokens": 100,
+        "n": 1,
+        "stop": None,
+        "temperature": 0.7,
+    }
+    response = requests.post(url, headers=headers, json=body)
+    if resp_type == "text":
+        text_resp = response.json()["choices"][0]["message"]["content"]
+        return text_resp
+    return response.json()


### PR DESCRIPTION
Previous version of sarathi retrieves OpenAI API key from the OPENAI_API_KEY environment variable.
The new version retrieves from SARATHI_OPENAI_API_KEY.

This PR makes sarathi try to retrieve the key from OPENAI_API_KEY in case SARATHI_OPENAI_API_KEY is undefined.

Tested by dogfooding of running `sarathi docstrgen -f src/sarathi/llm/call_llm.py`.